### PR TITLE
Load user config file closes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ pip install artifact-cli
 - project/plugins.sbt
 
 ```
-addSbtPlugin("jp.ne.opt" % "sbt-art" % "0.1.2")
+addSbtPlugin("jp.ne.opt" % "sbt-art" % "0.1.3")
 ```
 
 ### 3. Write AWS configuration
 
-- project/artifact-cli.conf
+- ~/.artifact-cli.conf (prior) or project/artifact-cli.conf
+
+Load ~/.artifact-cli.conf if it exists, otherwise load project/artifact-cli.conf.
 
 ```
 [default]
@@ -80,10 +82,16 @@ artTarget in art := (packageBin in Universal).value
 
 #### 4.3 artConfig (optional)
 
-Path to the configuration file for artifact-cli is also customizable. Default is ```project/artifact-cli.conf```.
+Path to the configuration file for artifact-cli is also customizable. Default is ```~/.artifact-cli.conf``` or ```project/artifact-cli.conf```.
 
 ```
 artConfig in art := new File("path/to/your.conf")
+```
+
+Use environment variable to specify configuration file.
+
+```
+artConfig in art := sys.env.get("VARNAME").map(new File(_)).getOrElse((artConfig in art).value)
 ```
 
 ## Tasks

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-  version := "0.1.2",
+  version := "0.1.3",
   organization := "jp.ne.opt",
   organizationName := "Opt, Inc.",
   startYear := Some(2015)

--- a/src/main/scala/jp/ne/opt/sbtart/SbtArtPlugin.scala
+++ b/src/main/scala/jp/ne/opt/sbtart/SbtArtPlugin.scala
@@ -33,7 +33,10 @@ object SbtArtPlugin extends sbt.AutoPlugin {
     artInfo <<= SbtArt.infoTask(art),
     artUpload := SbtArt.uploadTask(art).value,
 
-    artConfig := new File("project/artifact-cli.conf"),
+    artConfig := {
+      val f = new File(sys.env.get("HOME").map(_ + "/.artifact-cli.conf").getOrElse(""))
+      if (f.exists) f else new File("project/artifact-cli.conf")
+    },
     artGroupId := Keys.organization.value,
     artTarget := new File("")
   )


### PR DESCRIPTION
If user config file exists, load it instead of project's config file.
This is in order to change S3 backet for local deploy.
